### PR TITLE
タグ作成のレイアウトを整えた

### DIFF
--- a/frontend/src/components/AddRestaurantForm.tsx
+++ b/frontend/src/components/AddRestaurantForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useCallback, useMemo } from 'react';
+import { useRouter } from 'next/navigation';
 import InlineTagCreator from './InlineTagCreator';
 import HeadlessDropdown from './HeadlessDropdown';
 import Alert from './Alert';
@@ -12,6 +13,7 @@ import { authApi } from '@/lib/apiClient';
 import type { CreateRestaurantRequest, Tag } from '@/types/api';
 
 const AddRestaurantForm = () => {
+  const router = useRouter();
   const { areaTags, genreTags, loading, error, createTag, creating } = useTags();
   const [name, setName] = useState("");
   const [areaId, setAreaId] = useState("");
@@ -96,17 +98,22 @@ const AddRestaurantForm = () => {
         throw new Error(result.error);
       }
 
-      setSuccess(true);
-      setName("");
-      setAreaId("");
-      setGenreId("");
+      if (result.data && result.data.id) {
+        setSuccess(true);
+        // 成功メッセージを表示してからリダイレクト
+        setTimeout(() => {
+          router.push(`/restaurants/${result.data?.id}`);
+        }, 1000);
+      } else {
+        throw new Error("レストランIDが取得できませんでした");
+      }
       
     } catch (e: unknown) {
       setSubmitError(e instanceof Error ? e.message : "登録中にエラーが発生しました");
     } finally {
       setSubmitLoading(false);
     }
-  }, [name, areaId, genreId]);
+  }, [name, areaId, genreId, router]);
 
   if (loading) {
     return (
@@ -139,7 +146,7 @@ const AddRestaurantForm = () => {
         {success && (
           <Alert type="success">
             <i className="bi bi-check-circle me-2"></i>
-            店舗が正常に登録されました！
+            店舗が正常に登録されました！詳細ページへリダイレクトしています...
           </Alert>
         )}
 

--- a/frontend/src/components/InlineTagCreator.tsx
+++ b/frontend/src/components/InlineTagCreator.tsx
@@ -1,5 +1,11 @@
 import React, { useState } from 'react';
 import type { Tag, CreateTagRequest } from '@/types/api';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { PlusCircle, Check, X, AlertTriangle } from 'lucide-react';
+// import { cn } from '@/lib/utils';
 
 interface InlineTagCreatorProps {
   category: 'area' | 'genre';
@@ -57,69 +63,75 @@ const InlineTagCreator: React.FC<InlineTagCreatorProps> = ({
   const categoryLabel = category === 'area' ? 'エリア' : 'ジャンル';
 
   return (
-    <div className="border rounded p-3 mb-3 bg-light">
-      <h6 className="mb-3">
-        <i className="bi bi-plus-circle me-2"></i>
-        新しい{categoryLabel}を追加
-      </h6>
-      
-      {error && (
-        <div className="alert alert-danger alert-sm mb-2">
-          <i className="bi bi-exclamation-triangle me-2"></i>
-          {error}
-        </div>
-      )}
+    <Card className="mb-3">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <PlusCircle className="h-4 w-4" />
+          新しい{categoryLabel}を追加
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {error && (
+          <div className="mb-3 p-3 rounded-md bg-destructive/10 text-destructive flex items-start gap-2">
+            <AlertTriangle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+            <span className="text-sm">{error}</span>
+          </div>
+        )}
 
-      <div>
-        <div className="mb-3">
-          <label htmlFor={`new-${category}-name`} className="form-label">
-            {categoryLabel}名 <span className="text-danger">*</span>
-          </label>
-          <input
-            type="text"
-            className="form-control"
-            id={`new-${category}-name`}
-            value={name}
-            onChange={e => setName(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder={`新しい${categoryLabel}名を入力`}
-            disabled={creating}
-            maxLength={255}
-            required
-          />
-        </div>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor={`new-${category}-name`}>
+              {categoryLabel}名 <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              type="text"
+              id={`new-${category}-name`}
+              value={name}
+              onChange={e => setName(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={`新しい${categoryLabel}名を入力`}
+              disabled={creating}
+              maxLength={255}
+              required
+              className="w-full"
+            />
+          </div>
 
-        <div className="d-flex gap-2">
-          <button
-            type="button"
-            className="btn btn-primary btn-sm"
-            onClick={handleSubmit}
-            disabled={creating || !name.trim()}
-          >
-            {creating ? (
-              <>
-                <span className="spinner-border spinner-border-sm me-2" />
-                作成中...
-              </>
-            ) : (
-              <>
-                <i className="bi bi-check-lg me-2"></i>
-                作成
-              </>
-            )}
-          </button>
-          <button
-            type="button"
-            className="btn btn-secondary btn-sm"
-            onClick={onClose}
-            disabled={creating}
-          >
-            <i className="bi bi-x-lg me-2"></i>
-            キャンセル
-          </button>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              onClick={handleSubmit}
+              disabled={creating || !name.trim()}
+              size="sm"
+              className="flex items-center gap-2"
+            >
+              {creating ? (
+                <>
+                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                  作成中...
+                </>
+              ) : (
+                <>
+                  <Check className="h-4 w-4" />
+                  作成
+                </>
+              )}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onClose}
+              disabled={creating}
+              size="sm"
+              className="flex items-center gap-2"
+            >
+              <X className="h-4 w-4" />
+              キャンセル
+            </Button>
+          </div>
         </div>
-      </div>
-    </div>
+      </CardContent>
+    </Card>
   );
 };
 


### PR DESCRIPTION
## 修正点
- InlineTagCreatorコンポーネントのレイアウトを整えた
  - Bootstrapコードが残っていたためレイアウトが崩れていたが、tailwindcss + shadcnにした
- 店舗登録完了後に店舗詳細ページにリダイレクトするようにした