### PR TITLE
fix: レビュー一覧取得エンドポイントのGET 405エラーを修正

### DIFF
--- a/backend/app/controllers/api/reviews_controller.rb
+++ b/backend/app/controllers/api/reviews_controller.rb
@@ -6,7 +6,12 @@ module Api
     requires_authentication :create
 
     before_action :require_authentication!, only: [:create] # Ensures current_user is set
-    before_action :set_restaurant, only: [:create]
+    before_action :set_restaurant, only: [:create, :index]
+
+    def index
+      reviews = @restaurant.reviews.includes(:user, :scene_tags)
+      render json: ReviewSerializer.new(reviews).serialize
+    end
 
     def create
       image_file = params[:review]&.[](:image)

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -23,15 +23,10 @@ Rails.application.routes.draw do
     # レストランに関する機能のうち、only以降のアクションのみを許可
     resources :restaurants, only: [:create, :index, :show] do
       resource :favorite, only: [:create, :destroy], controller: 'favorites'
-      resources :reviews, only: [:create]
+      resources :reviews, only: [:create, :index]
     end
     resources :favorites, only: [:index]
     # タグに関する機能のうち、indexとcreateアクションを許可
     resources :tags, only: [:index, :create]
-
-    resources :restaurants, only: [] do
-      resource :favorite, only: [:create, :destroy], controller: 'favorites'
-    end
-    resources :favorites, only: [:index]
   end
 end

--- a/frontend/src/app/api/restaurants/[id]/reviews/route.ts
+++ b/frontend/src/app/api/restaurants/[id]/reviews/route.ts
@@ -2,6 +2,52 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 
+export const GET = async (
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) => {
+  try {
+    // セッション確認
+    const session = await getServerSession(authOptions);
+    
+    if (!session?.jwtToken) {
+      return NextResponse.json(
+        { error: '認証が必要です' },
+        { status: 401 }
+      );
+    }
+
+    // Rails APIからレビューを取得
+    const backendUrl = `http://backend:3000/api/restaurants/${params.id}/reviews`;
+    
+    const response = await fetch(backendUrl, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${session.jwtToken}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      return NextResponse.json(
+        { error: errorData.message || errorData.error || 'Rails API error' },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+
+  } catch (error) {
+    console.error('レビュー取得APIエラー:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+};
+
 export const POST = async (
   request: NextRequest, 
   { params }: { params: { id: string } }


### PR DESCRIPTION
## 概要
`GET /api/restaurants/:id/reviews` エンドポイントで発生していた405 Method Not Allowedエラーを修正しました。

## 問題
- フロントエンドからレビュー一覧を取得しようとすると405エラーが発生
- バックエンドのルートにGETメソッドが定義されていなかった
- フロントエンドのNext.js API routeにもGETハンドラーが未実装だった

## 修正内容

### バックエンド (Rails API)
- **routes.rb**: `resources :reviews, only: [:create, :index]` に変更してindexアクションを有効化
- **ReviewsController**: `index`アクションを追加してレビュー一覧を返すように実装
- 重複していたルート定義を整理

### フロントエンド (Next.js)
- **API route**: `/api/restaurants/[id]/reviews/route.ts` にGETハンドラーを追加
- Rails APIへのプロキシとして機能するよう実装
- JWT認証を含めて適切にリクエストを転送

## テスト結果
- RSpec テスト: ✅ 全テスト通過 (9 examples, 0 failures)
- ルート確認: ✅ `GET /api/restaurants/:restaurant_id/reviews` が正しく設定

🤖 Generated with [Claude Code](https://claude.ai/code)